### PR TITLE
Add method for getting ingredients required for N crafts

### DIFF
--- a/src/crafterlib/recipe.py
+++ b/src/crafterlib/recipe.py
@@ -44,6 +44,35 @@ class Recipe:
     
     def has_product(self, product: str) -> bool:
         return product in self.products
+    
+    def get_ingredients(self, num_crafts: float = 1) -> Dict[str, float]:
+        """Calculate the ingredients required to craft
+        this recipe `num_crafts` times.
+
+        Args
+        -- 
+            num_crafts: The number of times the recipe will be crafted.
+            If zero, an empty dict is always returned.
+        
+        Returns
+        -- 
+            Ingredient dict, example: `{"Item 1": 2, "Item 2": 4}`
+
+        Raises
+        --
+            ValueError if num_crafts was negative
+        """
+        if num_crafts < 0:
+            raise ValueError(f"Invalid number of crafts: {num_crafts}")
+        elif num_crafts == 0:
+            # edge case: just return the empty dict in this case
+            return {}
+        
+        ingredients_for_n = {}
+        for ingredient, amount in self.ingredients.items():
+            ingredients_for_n[ingredient] = amount * num_crafts
+
+        return ingredients_for_n
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a representation of the recipe as a dictionary."""

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,0 +1,78 @@
+"""This file is part of crafterlib.
+
+SPDX-License-Identifier: MIT
+"""
+from typing import Dict
+import pytest
+
+from crafterlib import Recipe
+
+test_recipe_dict = {
+    "id": 1,
+    "category": "Crafting",
+    "ingredients": {
+        "Iron Ingot": 3,
+        "Sticks": 2
+    },
+    "products": {
+        "Iron Pickaxe": 1
+    },
+    "requirements": {
+        "Crafting Table": 1
+    }
+}
+
+def test_recipe_from_dict():
+    recipe: Recipe = Recipe.from_dict(test_recipe_dict)
+
+    # check if all the recipe's fields are correct,
+    # i.e. if it was correctly parsed from the dict
+    assert recipe.id == 1
+    assert recipe.category == "Crafting"
+    assert recipe.ingredients == {
+        "Iron Ingot": 3,
+        "Sticks": 2
+    }
+    assert recipe.products == {
+        "Iron Pickaxe": 1
+    }
+    assert recipe.requirements == {
+        "Crafting Table": 1
+    }
+
+def test_recipe_ingredients_for_1():
+    recipe: Recipe = Recipe.from_dict(test_recipe_dict)
+
+    # default (get_ingredients with no parameters) should be 1
+    ingredients: Dict[str, float] = recipe.get_ingredients()
+
+    assert len(ingredients) == 2
+    assert ingredients["Iron Ingot"] == pytest.approx(3)
+    assert ingredients["Sticks"] == pytest.approx(2)
+
+def test_recipe_ingredients_for_several():
+    recipe: Recipe = Recipe.from_dict(test_recipe_dict)
+
+    ingredients: Dict[str, float] = recipe.get_ingredients(4)
+
+    # should be 12 ingots, 8 sticks required for 4 pickaxes
+    assert len(ingredients) == 2
+    assert ingredients["Iron Ingot"] == pytest.approx(12)
+    assert ingredients["Sticks"] == pytest.approx(8)
+
+def test_recipe_ingredients_for_zero():
+    recipe: Recipe = Recipe.from_dict(test_recipe_dict)
+
+    # edge case: if we try to craft zero of an item,
+    # it should return an empty dict
+    ingredients: Dict[str, float] = recipe.get_ingredients(0)
+
+    assert ingredients == {}
+
+def test_recipe_ingredients_for_negative():
+    recipe: Recipe = Recipe.from_dict(test_recipe_dict)
+
+    # edge case: if we try to craft negative of an item, it should
+    # raise ValueError
+    with pytest.raises(ValueError):
+        recipe.get_ingredients(-2)


### PR DESCRIPTION
Will resolve this issue: https://github.com/JFarNTIG/crafterlib/issues/1

- [X] My code follows the style guide (`docs/style.md`)
- [X] Unit tests were added
- [ ] Unit tests will be added later after some review
- [ ] Unit tests weren't necessary

I opted to add a method `get_ingredients` to Recipe. Adding a method to Recipe instead of a new util function makes the most sense, because it's easy to use generally as long as you have a Recipe object.

Now someone could compute ingredients required for N crafts like this:
```python
recipes = game_data.get_recipes_for_item("Iron Ingot")
recipe = recipes[0] # assuming at least 1 recipe exists
ingredients = recipe.get_ingredients(3) # ingredients for 3 crafts

# now ingredients has amounts required to craft N
```

I added new unit tests to test a simple recipe at different number of crafts:

- test when N=1
- test when N=4
- test when N=0 (edge case)
- test when N is negative (edge case)

Also, I added a test for Recipe and creating Recipe from a dict, since there were no basic unit tests for Recipe yet.

Currently, the tests are all passing.