### PR TITLE
Fix recipe for Sticks

### DIFF
--- a/src/crafterlib/data/games/minecraft/recipes.json
+++ b/src/crafterlib/data/games/minecraft/recipes.json
@@ -39,7 +39,7 @@
         "category": "Crafting",
         "requirements": {},
         "ingredients": {
-            "Planks": 1
+            "Planks": 2
         },
         "products": {
             "Sticks": 4


### PR DESCRIPTION
Before, the recipe for Sticks in Minecraft was incorrect, it was 1 planks for 4 sticks. However, the correct recipe is 2 planks for 4 sticks.

This PR changes the recipe (recipes.json in Minecraft folder) so that it is 2 planks for 4 sticks instead.

Unit tests were not added; maybe in the future, some way of unit testing recipes for each game would be nice to have.

Instead, we manually tested with an example before committing.