### PR TITLE
Add crafting grid feature

### DIFF
--- a/examples/minecraft_crafting_grid.py
+++ b/examples/minecraft_crafting_grid.py
@@ -1,0 +1,32 @@
+"""This example code file shows how crafterlib can be used ...
+
+SPDX-License-Identifier: MIT
+"""
+
+import crafterlib
+
+# crafterlib provides a function `load_data_for_game` to load item
+# and crafting data for a certain game.
+
+game_data = crafterlib.load_data_for_game("minecraft")
+
+item_name = "Furnace"
+
+crafting_grids = game_data.get_crafting_grid_for_item(item_name)
+
+for crafting_grid in crafting_grids:
+    print("The crafting grid for",item_name,"is: \n")
+    for coordinate,item in crafting_grid.crafting_coordinates.items():
+        print(coordinate,item)
+
+# Very simple visual representation of the crafting grid, could be implemented in a more refined way
+for crafting_grid in crafting_grids:
+    print("\nThe crafting grid for",item_name,"is: \n")
+    print("___________________________________________")
+    print("|",crafting_grid.crafting_coordinates["A1"], "|",crafting_grid.crafting_coordinates["A2"], "|",crafting_grid.crafting_coordinates["A3"], "|" )
+    print("___________________________________________")
+    print("|",crafting_grid.crafting_coordinates["B1"], "|",crafting_grid.crafting_coordinates["B2"], "|",crafting_grid.crafting_coordinates["B3"], "|" )
+    print("___________________________________________")
+    print("|",crafting_grid.crafting_coordinates["C1"], "|",crafting_grid.crafting_coordinates["C2"], "|",crafting_grid.crafting_coordinates["C3"], "|" )
+    print("___________________________________________")
+

--- a/examples/minecraft_crafting_grid.py
+++ b/examples/minecraft_crafting_grid.py
@@ -5,9 +5,6 @@ SPDX-License-Identifier: MIT
 
 import crafterlib
 
-# crafterlib provides a function `load_data_for_game` to load item
-# and crafting data for a certain game.
-
 game_data = crafterlib.load_data_for_game("minecraft")
 
 item_name = "Furnace"
@@ -19,7 +16,8 @@ for crafting_grid in crafting_grids:
     for coordinate,item in crafting_grid.crafting_coordinates.items():
         print(coordinate,item)
 
-# Very simple visual representation of the crafting grid, could be implemented in a more refined way
+# Very simple visual representation of the crafting grid, this could be implemented in a 
+# more user friendly way by having a graphic display of the data.
 for crafting_grid in crafting_grids:
     print("\nThe crafting grid for",item_name,"is: \n")
     print("___________________________________________")

--- a/src/crafterlib/crafting_data.py
+++ b/src/crafterlib/crafting_data.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT
 from typing import Dict, List, Optional
 from crafterlib.item import Item
 from crafterlib.recipe import Recipe
+from crafterlib.crafting_grid import CraftingGrid
 from crafterlib.graph import ItemGraph
 
 def _make_item_id_map(items: List[Item]):
@@ -38,10 +39,11 @@ def _make_recipe_id_map(recipes: List[Recipe]):
     return recipe_id_map
 
 class GameCraftingData:
-    def __init__(self, name: str, items: List[Item] = [], recipes: List[Recipe] = []):
+    def __init__(self, name: str, items: List[Item] = [], recipes: List[Recipe] = [], crafting_grids: List[CraftingGrid] = []):
         self.name = name
         self.items = items
         self.recipes = recipes
+        self.crafting_grids = crafting_grids
         self.item_id_map = _make_item_id_map(items)
         self.item_name_map = _make_item_name_map(items)
         self.recipe_id_map = _make_recipe_id_map(recipes)
@@ -75,3 +77,13 @@ class GameCraftingData:
                 recipes_for_item.append(recipe)
         return recipes_for_item
     
+    def get_crafting_grid_for_item(self, item_name: str) -> List[CraftingGrid]:
+       """Get all crafting grid recipes in which the specified
+       item appears as a product.
+       """
+       crafting_grids_for_item = []
+
+       for crafting_grid in self.crafting_grids:
+           if crafting_grid.has_product(item_name):
+               crafting_grids_for_item.append(crafting_grid )
+       return crafting_grids_for_item

--- a/src/crafterlib/crafting_data.py
+++ b/src/crafterlib/crafting_data.py
@@ -57,6 +57,9 @@ class GameCraftingData:
     def num_recipes(self):
         return len(self.recipes)
     
+    def num_crafting_grids(self):
+        return len(self.crafting_grids)
+    
     def get_item_by_id(self, id: int) -> Optional[Item]:
         return self.item_id_map.get(id)
     

--- a/src/crafterlib/crafting_grid.py
+++ b/src/crafterlib/crafting_grid.py
@@ -1,0 +1,37 @@
+"""This file is part of crafterlib.
+
+SPDX-License-Identifier: MIT
+"""
+from typing import Dict, Any
+
+class CraftingGrid:
+    """
+    A class to use the crafting grid 
+
+    Attributes
+    ---
+    crafting_coordinates : a representation of a crafting grid using coordinates (A1, A2, A3, B1...) 
+    in the form of a dictionary
+
+    product : The name of the product attached to the crafting grid recipe
+    """
+
+    def __init__(self, product: str, crafting_coordinates: Dict[str,str] = {}):
+        self.crafting_coordinates = crafting_coordinates
+        self.product = product
+
+    def has_product(self, product: str) -> bool:
+        """
+        Returns true if the crafting recipe contains the provided product
+        """
+        return product in self.product
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CraftingGrid":
+        """
+        Build a CraftingGrid instance from a plain dictionary.
+        """
+        return cls(
+            crafting_coordinates=data.get("crafting_coordinates",{}),
+            product=data.get("product", "")
+        )

--- a/src/crafterlib/crafting_grid.py
+++ b/src/crafterlib/crafting_grid.py
@@ -10,8 +10,7 @@ class CraftingGrid:
 
     Attributes
     ---
-    crafting_coordinates : a representation of a crafting grid using coordinates (A1, A2, A3, B1...) 
-    in the form of a dictionary
+    crafting_coordinates : a representation of a crafting grid using coordinates (A1, A2, A3, B1...) in the form of a dictionary
 
     product : The name of the product attached to the crafting grid recipe
     """
@@ -30,6 +29,16 @@ class CraftingGrid:
     def from_dict(cls, data: Dict[str, Any]) -> "CraftingGrid":
         """
         Build a CraftingGrid instance from a plain dictionary.
+
+        Parameters
+        ---
+
+        data : a representation of a crafting grid using coordinates (A1, A2, A3, B1...) in the form of a dictionary
+
+        Returns
+        ---
+        A crafting grid instance built upon the dictionary provided
+
         """
         return cls(
             crafting_coordinates=data.get("crafting_coordinates",{}),

--- a/src/crafterlib/data/games/minecraft/crafting_grids.json
+++ b/src/crafterlib/data/games/minecraft/crafting_grids.json
@@ -1,0 +1,31 @@
+[
+    {
+        "product": "Furnace",
+        "crafting_coordinates": {
+            "A1": "Cobblestone",
+            "A2": "Cobblestone",
+            "A3": "Cobblestone",
+            "B1": "Cobblestone",
+            "B2": "empty",
+            "B3": "Cobblestone",
+            "C1": "Cobblestone",
+            "C2": "Cobblestone",
+            "C3": "Cobblestone"
+        }
+    },
+
+    {
+        "product": "Crafting Table",
+        "crafting_coordinates": {
+            "A1": "Empty",
+            "A2": "Empty",
+            "A3": "Empty",
+            "B1": "Wooden Planks",
+            "B2": "Wooden Planks",
+            "B3": "Empty",
+            "C1": "Wooden Planks",
+            "C2": "Wooden Planks",
+            "C3": "Empty"
+        }
+    }
+]

--- a/src/crafterlib/data/games/minecraft/root.json
+++ b/src/crafterlib/data/games/minecraft/root.json
@@ -7,5 +7,8 @@
     ],
     "recipe_files": [
         "recipes.json"
+    ],
+    "crafting_grid_files": [
+        "crafting_grids.json"
     ]
 }

--- a/test_data/games/test_game/crafting_grids.json
+++ b/test_data/games/test_game/crafting_grids.json
@@ -1,0 +1,25 @@
+[
+    {
+        "product": "Dough",
+        "crafting_coordinates": {
+            "A1": "Water",
+            "A2": "Flour"
+        }
+    },
+
+    {
+        "product": "Pepperoni",
+        "crafting_coordinates": {
+            "A1": "Meat",
+            "A2": "Salt"
+        }
+    },
+
+    {
+        "product": "Cheese",
+        "crafting_coordinates": {
+            "A1": "Milk",
+            "A2": "Vinegar"
+        }
+    }
+]

--- a/test_data/games/test_game/root.json
+++ b/test_data/games/test_game/root.json
@@ -5,5 +5,8 @@
     ],
     "recipe_files": [
         "recipes.json"
+    ],
+    "crafting_grid_files": [
+        "crafting_grids.json"
     ]
 }

--- a/tests/test_crafting_grid.py
+++ b/tests/test_crafting_grid.py
@@ -1,0 +1,47 @@
+"""This file is part of crafterlib.
+
+SPDX-License-Identifier: MIT
+"""
+from typing import Dict
+import pytest
+
+from crafterlib.crafting_grid import CraftingGrid
+
+test_crafting_grid_dict = {
+    "product": "Furnace",
+    "crafting_coordinates": {
+        "A1": "Cobblestone",
+        "A2": "Cobblestone",
+        "A3": "Cobblestone",
+        "B1": "Cobblestone",
+        "B2": "empty",
+        "B3": "Cobblestone",
+        "C1": "Cobblestone",
+        "C2": "Cobblestone",
+        "C3": "Cobblestone"
+    }
+}
+
+def test_has_product():
+    crafting_grid: CraftingGrid = CraftingGrid.from_dict(test_crafting_grid_dict)
+    item_name1 = crafting_grid.product
+    item_name2 = "Grass"
+
+    assert crafting_grid.has_product(item_name1) == True
+    assert crafting_grid.has_product(item_name2) == False
+
+
+def test_crafting_grid_from_dict():
+    crafting_grid: CraftingGrid = CraftingGrid.from_dict(test_crafting_grid_dict)
+    assert crafting_grid.product == "Furnace"
+    assert crafting_grid.crafting_coordinates == {
+        "A1": "Cobblestone",
+        "A2": "Cobblestone",
+        "A3": "Cobblestone",
+        "B1": "Cobblestone",
+        "B2": "empty",
+        "B3": "Cobblestone",
+        "C1": "Cobblestone",
+        "C2": "Cobblestone",
+        "C3": "Cobblestone"
+    }

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -8,6 +8,7 @@ def test_load_data():
     game_data = load_data_for_game("test_game", "test_data")
     assert game_data.num_items() == 13
     assert game_data.num_recipes() == 5
+    assert game_data.num_crafting_grids() == 3
 
 def test_item_parsing():
     game_data = load_data_for_game("test_game", "test_data")


### PR DESCRIPTION
Will resolve this issue: #8

- [x] My code follows the style guide (docs/style.md)
- [x] Unit tests were added
- [ ] Unit tests will be added later after some review
- [ ] Unit tests weren't necessary

Before there were no features for displaying crafting grids, this became an issue for games like minecraft that rely heavily on both the amount needed to craft something but also how it should be arranged on the crafting table. 

This PR resolves this issue by adding a feature to the project that makes it possible to display crafting grid instructions. 

I chose to do this by adding a new class called crafting_grid that can be used to display instructions for the crafting grid to a user. I have also added an example file called minecraft_crafting_grid that shows how this new class can be used. 

I have only added two crafting recipes in the crafting_grids json file since its all that was needed to create this feature, in the future it would be good to extend the data with more crafting_grid recipes.

I also added unit tests for the class:

- crafting_grid.has_product() == True and crafting_grid.has_product() == False
- Test of an example dict to make sure the data is displayed properly

