### PR TITLE
Add Minecraft potion recipes and function for getting recipe chains

### DIFF
--- a/examples/minecraft_recipe_chain.py
+++ b/examples/minecraft_recipe_chain.py
@@ -1,0 +1,85 @@
+"""This example code file shows how crafterlib can be used to get
+a sequence of steps needed to craft an item from an indirect ingredient,
+another item that is not a direct ingredient to the first item.
+
+If you have a Log for example and want to make a Pickaxe out of it,
+then you can use the utility function get_recipe_chain to get a list
+of ingredients and products for each crafting step inbetween these two
+items.
+
+This function is especially helpfull for getting complete recipes for
+potions in minecraft which are made in multiple steps.
+
+SPDX-License-Identifier: MIT
+"""
+import crafterlib
+import crafterlib.craftutils as craftutils
+
+game_data = crafterlib.load_data_for_game("minecraft")
+
+# Get step by step instructions for crafting an Iron Pickaxe from Logs.
+ingredient_name = "Logs"
+product_name = "Iron Pickaxe"
+
+# Get a list of recipes in short form.
+recipe_chain = craftutils.get_recipe_chain(game_data,
+                                           ingredient_name,
+                                           product_name)
+
+print(f"\nMake {product_name} from {ingredient_name}:")
+
+# Loop through the recipes.
+# Each recipe is one step in the crafting process.
+for i, step in enumerate(recipe_chain):
+
+    # Every step in this example only has one type of item as product.
+    # Get the name of the product (key) and the amount of this product
+    # that will be crafted (value).
+    product_key, product_value = next(iter(step["products"].items()))
+    print(f"Step {i+1}. Craft {product_value} {product_key} from ", end="")
+
+    # Loop through and print the ingredients in a similar way.
+    for ingredient in step["ingredients"].items():
+        ingredient_key, ingredient_value = ingredient
+        print(f"{ingredient_value} {ingredient_key}, ", end="")
+    print()
+
+
+# In this other example we will get instructions for brewing a
+# Lingering Potion of Invisibility.
+# Brewing is a little different than regular crafting because a potion is
+# made in a brewing stand by adding ingredients to Water Bottles in a
+# specific order. With the help of the get_recipe_chain function we can get
+# all these ingredients in the correct order.
+ingredient_name = "Water Bottle"
+product_name = "Lingering Potion of Invisibility"
+
+# Get a list of recipes in short form.
+# When calling the function we can add the forth parameter `combine_ingredients`.
+# Brewing a potion requires a little Blaze Powder as a second ingredient in
+# every step, but all this can be added in the first step.´
+# With `combine_ingredients` set, the function will calculate how much
+# Blaze Powder that's needed for all steps and only return it as one ingredient
+# in the first step.
+recipe_chain = craftutils.get_recipe_chain(game_data,
+                                           ingredient_name,
+                                           product_name,
+                                           combine_ingredients=True)
+
+print(f"\nMake {product_name} from {ingredient_name}:")
+
+# Loop through the recipes.
+# Each recipe is one step in the brewing process.
+for i, step in enumerate(recipe_chain):
+
+    print(f"Step {i+1}.", end="")
+
+    # Loop through and print the ingredients and their amount.
+    for ingredient in step["ingredients"].items():
+        ingredient_key, ingredient_value = ingredient
+        print(f" {ingredient_value} {ingredient_key} +", end="")
+    print("\b-> ", end="")
+
+    # Print the product.
+    product_key, product_value = next(iter(step["products"].items()))
+    print(f"{product_value} {product_key}, ")

--- a/src/crafterlib/craftutils/__init__.py
+++ b/src/crafterlib/craftutils/__init__.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: MIT
 __all__ = [
     "get_amount_needed_for",
     "get_amount_craftable_with",
+    "get_recipe_chain",
     "get_recyclables",
     "get_possible_products",
     "get_basic_resources",
@@ -19,6 +20,7 @@ __all__ = [
 
 from .amount_needed_for import get_amount_needed_for
 from .amount_craftable_with import get_amount_craftable_with
+from .recipe_chain import get_recipe_chain
 from .recyclables import get_recyclables
 from .possible_products import get_possible_products
 from .resources_basic import get_basic_resources, get_basic_resources_for

--- a/src/crafterlib/craftutils/recipe_chain.py
+++ b/src/crafterlib/craftutils/recipe_chain.py
@@ -1,0 +1,56 @@
+"""This file is part of crafterlib.
+
+SPDX-License-Identifier: MIT
+"""
+from crafterlib import GameCraftingData
+
+def get_recipe_chain(game_data: GameCraftingData,
+                     ingredient: str,
+                     product: str,
+                     combine_ingredients: bool = False) -> list:
+    """Get a chain of recipes that connect `ingredient` to `product`.
+
+    Returns a list of dictionaries with ingredients and products
+    for every recipe inbetween `ingredient` and `product`.
+    The recipes' `id`, `category` and `requirements` will not be
+    included.
+
+    Example: `ingredient='Logs', product='Iron Pickaxe'` -> 
+    ```
+    [
+      {
+        "ingredients": {
+          "Logs": 1
+        },
+        "products": {
+          "Planks": 2
+        }
+      },
+      {
+        "ingredients": {
+          "Planks": 2
+        },
+        "products": {
+          "Sticks": 4
+        }
+      },
+      {
+        "ingredients": {
+          "Iron Ingot": 3,
+          "Sticks": 2
+        },
+        "products": {
+          "Iron Pickaxe": 1
+        }
+      }
+    ]
+    ```
+    If `combine_ingredients` is set, the ingredients of
+    different recipes will be summed up if they're the same
+    and be accounted for in the first step which they occur.
+
+    Returns None if no connection between `ingredient` and `product` is found.
+    """
+    # TODO: Finish this implementation.
+
+    raise NotImplementedError

--- a/src/crafterlib/craftutils/recipe_chain.py
+++ b/src/crafterlib/craftutils/recipe_chain.py
@@ -2,6 +2,7 @@
 
 SPDX-License-Identifier: MIT
 """
+import networkx as nx
 from crafterlib import GameCraftingData
 
 def get_recipe_chain(game_data: GameCraftingData,
@@ -47,10 +48,72 @@ def get_recipe_chain(game_data: GameCraftingData,
     ```
     If `combine_ingredients` is set, the ingredients of
     different recipes will be summed up if they're the same
-    and be accounted for in the first step which they occur.
+    and be accounted for in the first step in which they occur.
 
     Returns None if no connection between `ingredient` and `product` is found.
     """
-    # TODO: Finish this implementation.
+    # If `ingredient` and `product` are the same,
+    # this funciton should return None.
+    if ingredient == product:
+        return None
 
-    raise NotImplementedError
+    graph = game_data.item_graph.graph
+
+    try:
+        # Dijkstra's algorithm gives us the shortest path between
+        # `ingredient` and `product`.
+        path = nx.dijkstra_path(graph, ingredient, product, weight="weight")
+    except nx.NodeNotFound:
+        # can happen if `ingredient` is not in the graph
+        return None
+    except nx.NetworkXNoPath:
+        # there is no way to get from `ingredient` to `product`
+        return None
+
+    chain = []
+
+    # Loop through every product in the path and collect their recipes
+    for i, item in enumerate(path[1:]):
+        recipes = game_data.get_recipes_for_item(item)
+        for recipe in recipes:
+            recipe = recipe.to_dict()
+
+            # Find the recipe with the previous product as an ingredient
+            # and remove unwanted data.
+            if path[i] in recipe['ingredients'].keys():
+                recipe.pop("id")
+                recipe.pop("category")
+                recipe.pop("requirements")
+                chain.append(recipe)
+                break
+        
+        # If combine ingredients is set and there are more than one
+        # recipe/step in the chain list.
+        if combine_ingredients and i > 0:
+            ingredients_to_remove = []
+
+            # Loop through the ingredients in the new step
+            for new_ingredient in chain[-1]['ingredients']:
+
+                # Loop through the previous steps i the chain
+                for index, step in enumerate(chain[:-1]):
+
+                    # and loop through their ingredients
+                    for step_ingredient in step['ingredients']:
+
+                        # If a new ingredient is used in a previous step,
+                        # add it to the previous step and save so it can be
+                        # removed from the new step later.
+                        if new_ingredient == step_ingredient:
+                            chain[index]['ingredients'][step_ingredient] += chain[-1]['ingredients'][new_ingredient]
+                            ingredients_to_remove.append(step_ingredient)
+                            break
+                    else:
+                        continue
+                    break
+            
+            # Remove ingredients that have been combined from the new step
+            for _ingredient in ingredients_to_remove:
+                chain[-1]['ingredients'].pop(_ingredient)
+
+    return chain

--- a/src/crafterlib/craftutils/recipe_chain.py
+++ b/src/crafterlib/craftutils/recipe_chain.py
@@ -53,7 +53,7 @@ def get_recipe_chain(game_data: GameCraftingData,
     Returns None if no connection between `ingredient` and `product` is found.
     """
     # If `ingredient` and `product` are the same,
-    # this funciton should return None.
+    # this function should return None.
     if ingredient == product:
         return None
 

--- a/src/crafterlib/data/games/minecraft/recipes.json
+++ b/src/crafterlib/data/games/minecraft/recipes.json
@@ -178,5 +178,76 @@
         "products": {
             "Torch": 4
         }
+    },
+    {
+        "id": 1000,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Spider Eye": 1,
+            "Sugar": 1,
+            "Brown Mushroom": 1
+        },
+        "products": {
+            "Fermented Spider Eye": 1
+        }
+    },
+    {
+        "id": 1001,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Melon Slice": 1,
+            "Gold Nugget": 8
+        },
+        "products": {
+            "Glistering Melon Slice": 1
+        }
+    },
+    {
+        "id": 1002,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Carrot": 1,
+            "Gold Nugget": 8
+        },
+        "products": {
+            "Gold Carrot": 1
+        }
+    },
+    {
+        "id": 1003,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Blaze Powder": 1,
+            "Slimeball": 1
+        },
+        "products": {
+            "Magma Cream": 1
+        }
+    },
+    {
+        "id": 1004,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Turtle Scute": 5
+        },
+        "products": {
+            "Turtle Shell": 1
+        }
+    },
+    {
+        "id": 1005,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Block of Redstone": 1
+        },
+        "products": {
+            "Redstone Dust": 9
+        }
     }
 ]

--- a/src/crafterlib/data/games/minecraft/recipes.json
+++ b/src/crafterlib/data/games/minecraft/recipes.json
@@ -196,7 +196,9 @@
     {
         "id": 1000,
         "category": "Crafting",
-        "requirements": {},
+        "requirements": {
+            "Crafting Table": 1
+        },
         "ingredients": {
             "Glass": 3
         },
@@ -220,7 +222,9 @@
     {
         "id": 1002,
         "category": "Crafting",
-        "requirements": {},
+        "requirements": {
+            "Crafting Table": 1
+        },
         "ingredients": {
             "Melon Slice": 1,
             "Gold Nugget": 8
@@ -232,7 +236,9 @@
     {
         "id": 1003,
         "category": "Crafting",
-        "requirements": {},
+        "requirements": {
+            "Crafting Table": 1
+        },
         "ingredients": {
             "Carrot": 1,
             "Gold Nugget": 8
@@ -256,7 +262,9 @@
     {
         "id": 1005,
         "category": "Crafting",
-        "requirements": {},
+        "requirements": {
+            "Crafting Table": 1
+        },
         "ingredients": {
             "Turtle Scute": 5
         },

--- a/src/crafterlib/data/games/minecraft/recipes.json
+++ b/src/crafterlib/data/games/minecraft/recipes.json
@@ -180,7 +180,32 @@
         }
     },
     {
+        "id": 15,
+        "category": "Smelting",
+        "requirements": {
+            "Furnace": 1
+        },
+        "ingredients": {
+            "Sand": 1,
+            "Coal": 0.125
+        },
+        "products": {
+            "Glass": 1
+        }
+    },
+    {
         "id": 1000,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Glass": 3
+        },
+        "products": {
+            "Glass Bottle": 3
+        }
+    },
+    {
+        "id": 1001,
         "category": "Crafting",
         "requirements": {},
         "ingredients": {
@@ -193,7 +218,7 @@
         }
     },
     {
-        "id": 1001,
+        "id": 1002,
         "category": "Crafting",
         "requirements": {},
         "ingredients": {
@@ -205,7 +230,7 @@
         }
     },
     {
-        "id": 1002,
+        "id": 1003,
         "category": "Crafting",
         "requirements": {},
         "ingredients": {
@@ -217,7 +242,7 @@
         }
     },
     {
-        "id": 1003,
+        "id": 1004,
         "category": "Crafting",
         "requirements": {},
         "ingredients": {
@@ -229,7 +254,7 @@
         }
     },
     {
-        "id": 1004,
+        "id": 1005,
         "category": "Crafting",
         "requirements": {},
         "ingredients": {
@@ -240,7 +265,7 @@
         }
     },
     {
-        "id": 1005,
+        "id": 1006,
         "category": "Crafting",
         "requirements": {},
         "ingredients": {

--- a/src/crafterlib/data/games/minecraft/recipes.json
+++ b/src/crafterlib/data/games/minecraft/recipes.json
@@ -180,7 +180,7 @@
         }
     },
     {
-        "id": 15,
+        "id": 99,
         "category": "Smelting",
         "requirements": {
             "Furnace": 1

--- a/src/crafterlib/data/games/minecraft/recipes_potions.json
+++ b/src/crafterlib/data/games/minecraft/recipes_potions.json
@@ -82,19 +82,26 @@
     { "id": 81, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of the Turtle Master": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of the Turtle Master": 3 } },
     { "id": 82, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of the Turtle Master": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of the Turtle Master": 3 } },
   
-    { "id": 83, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Any Base Ingredient": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
-    { "id": 84, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Mundane Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Mundane Potion": 3 } },
-    { "id": 85, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Mundane Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Mundane Potion": 3 } },
+    { "id": 83, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 84, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Ghast Tear": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 85, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Rabbit's Foot": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 86, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Blaze Powder": 1.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 87, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Glistering Melon Slice": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 88, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Sugar": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 89, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Magma Cream": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 90, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 91, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Mundane Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Mundane Potion": 3 } },
+    { "id": 92, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Mundane Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Mundane Potion": 3 } },
   
-    { "id": 86, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Thick Potion": 3 } },
-    { "id": 87, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Thick Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Thick Potion": 3 } },
-    { "id": 88, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Thick Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Thick Potion": 3 } },
+    { "id": 93, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Thick Potion": 3 } },
+    { "id": 94, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Thick Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Thick Potion": 3 } },
+    { "id": 95, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Thick Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Thick Potion": 3 } },
   
-    { "id": 89, "category": "Filling", "requirements": { "Water Source": 1 }, "ingredients": { "Glass Bottle": 1 }, "products": { "Water Bottle": 1 } },
-    { "id": 90, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Water Bottle": 3 } },
-    { "id": 91, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Water Bottle": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Water Bottle": 3 } },
+    { "id": 96, "category": "Filling", "requirements": { "Water Source": 1 }, "ingredients": { "Glass Bottle": 1 }, "products": { "Water Bottle": 1 } },
+    { "id": 97, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Water Bottle": 3 } },
+    { "id": 98, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Water Bottle": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Water Bottle": 3 } },
   
-    { "id": 92, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Nether Wart": 1, "Blaze Powder": 0.05 }, "products": { "Awkward Potion": 3 } },
-    { "id": 93, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Awkward Potion": 3 } },
-    { "id": 94, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Awkward Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Awkward Potion": 3 } }
+    { "id": 200, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Nether Wart": 1, "Blaze Powder": 0.05 }, "products": { "Awkward Potion": 3 } },
+    { "id": 201, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Awkward Potion": 3 } },
+    { "id": 202, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Awkward Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Awkward Potion": 3 } }
 ]

--- a/src/crafterlib/data/games/minecraft/recipes_potions.json
+++ b/src/crafterlib/data/games/minecraft/recipes_potions.json
@@ -90,7 +90,7 @@
     { "id": 87, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Thick Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Thick Potion": 3 } },
     { "id": 88, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Thick Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Thick Potion": 3 } },
   
-    { "id": 89, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Glass Bottle": 3, "Water Source": 1 }, "products": { "Water Bottle": 3 } },
+    { "id": 89, "category": "Filling", "requirements": { "Water Source": 1 }, "ingredients": { "Glass Bottle": 1 }, "products": { "Water Bottle": 1 } },
     { "id": 90, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Water Bottle": 3 } },
     { "id": 91, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Water Bottle": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Water Bottle": 3 } },
   

--- a/src/crafterlib/data/games/minecraft/recipes_potions.json
+++ b/src/crafterlib/data/games/minecraft/recipes_potions.json
@@ -1,0 +1,100 @@
+[
+    { "id": 15, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Fermented Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Weakness": 3 } },
+    { "id": 16, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Weakness": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Weakness": 3 } },
+    { "id": 17, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Weakness": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Weakness": 3 } },
+    
+    { "id": 18, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Ghast Tear": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Regeneration": 3 } },
+    { "id": 19, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Regeneration": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Regeneration II": 3 } },
+    { "id": 20, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Regeneration": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Regeneration +": 3 } },
+    { "id": 21, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Regeneration": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Regeneration": 3 } },
+    { "id": 22, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Regeneration": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Regeneration": 3 } },
+  
+    { "id": 23, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Glistering Melon Slice": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Healing": 3 } },
+    { "id": 24, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Healing": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Healing II": 3 } },
+    { "id": 25, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Healing": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Healing": 3 } },
+    { "id": 26, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Healing": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Healing": 3 } },
+  
+    { "id": 27, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Poison": 3 } },
+    { "id": 28, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Poison": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Poison II": 3 } },
+    { "id": 29, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Poison": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Poison +": 3 } },
+    { "id": 30, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Poison": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Poison": 3 } },
+    { "id": 31, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Poison": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Poison": 3 } },
+  
+    { "id": 32, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Healing": 3, "Fermented Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Harming": 3 } },
+    { "id": 33, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Poison": 3, "Fermented Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Harming": 3 } },
+    { "id": 34, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Harming": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Harming II": 3 } },
+    { "id": 35, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Harming": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Harming": 3 } },
+    { "id": 36, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Harming": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Harming": 3 } },
+  
+    { "id": 37, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Sugar": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Swiftness": 3 } },
+    { "id": 38, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Swiftness": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Swiftness II": 3 } },
+    { "id": 39, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Swiftness": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Swiftness +": 3 } },
+    { "id": 40, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Swiftness": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Swiftness": 3 } },
+    { "id": 41, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Swiftness": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Swiftness": 3 } },
+  
+    { "id": 42, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Swiftness": 3, "Fermented Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Slowness": 3 } },
+    { "id": 43, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Leaping": 3, "Fermented Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Slowness": 3 } },
+    { "id": 44, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Slowness": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Slowness II": 3 } },
+    { "id": 45, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Slowness": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Slowness +": 3 } },
+    { "id": 46, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Slowness": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Slowness": 3 } },
+    { "id": 47, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Slowness": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Slowness": 3 } },
+  
+    { "id": 48, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Magma Cream": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Fire Resistance": 3 } },
+    { "id": 49, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Fire Resistance": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Fire Resistance +": 3 } },
+    { "id": 50, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Fire Resistance": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Fire Resistance": 3 } },
+    { "id": 51, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Fire Resistance": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Fire Resistance": 3 } },
+  
+    { "id": 52, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Blaze Powder": 1.05 }, "products": { "Potion of Strength": 3 } },
+    { "id": 53, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Strength": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Strength II": 3 } },
+    { "id": 54, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Strength": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Strength +": 3 } },
+    { "id": 55, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Strength": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Strength": 3 } },
+    { "id": 56, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Strength": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Strength": 3 } },
+  
+    { "id": 57, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Golden Carrot": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Night Vision": 3 } },
+    { "id": 58, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Night Vision": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Night Vision +": 3 } },
+    { "id": 59, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Night Vision": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Night Vision": 3 } },
+    { "id": 60, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Night Vision": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Night Vision": 3 } },
+
+    { "id": 61, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Night Vision": 3, "Fermented Spider Eye": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Invisibility": 3 } },
+    { "id": 62, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Invisibility": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Invisibility +": 3 } },
+    { "id": 63, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Invisibility": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Invisibility": 3 } },
+    { "id": 64, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Invisibility": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Invisibility": 3 } },
+  
+    { "id": 65, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Rabbit's Foot": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Leaping": 3 } },
+    { "id": 66, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Leaping": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Leaping II": 3 } },
+    { "id": 67, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Leaping": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Leaping +": 3 } },
+    { "id": 68, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Leaping": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Leaping": 3 } },
+    { "id": 69, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Leaping": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Leaping": 3 } },
+  
+    { "id": 70, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Phantom Membrane": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Slow Falling": 3 } },
+    { "id": 71, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Slow Falling": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Slow Falling +": 3 } },
+    { "id": 72, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Slow Falling": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Slow Falling": 3 } },
+    { "id": 73, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Slow Falling": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Slow Falling": 3 } },
+  
+    { "id": 74, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Pufferfish": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Water Breathing": 3 } },
+    { "id": 75, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Water Breathing": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of Water Breathing +": 3 } },
+    { "id": 76, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of Water Breathing": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of Water Breathing": 3 } },
+    { "id": 77, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of Water Breathing": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of Water Breathing": 3 } },
+  
+    { "id": 78, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Turtle Shell": 1, "Blaze Powder": 0.05 }, "products": { "Potion of the Turtle Master": 3 } },
+    { "id": 79, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of the Turtle Master": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of the Turtle Master II": 3 } },
+    { "id": 80, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of the Turtle Master": 3, "Redstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Potion of the Turtle Master +": 3 } },
+    { "id": 81, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Potion of the Turtle Master": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Potion of the Turtle Master": 3 } },
+    { "id": 82, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Potion of the Turtle Master": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Potion of the Turtle Master": 3 } },
+  
+    { "id": 83, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Any Base Ingredient": 1, "Blaze Powder": 0.05 }, "products": { "Mundane Potion": 3 } },
+    { "id": 84, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Mundane Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Mundane Potion": 3 } },
+    { "id": 85, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Mundane Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Mundane Potion": 3 } },
+  
+    { "id": 86, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Glowstone Dust": 1, "Blaze Powder": 0.05 }, "products": { "Thick Potion": 3 } },
+    { "id": 87, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Thick Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Thick Potion": 3 } },
+    { "id": 88, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Thick Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Thick Potion": 3 } },
+  
+    { "id": 89, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Glass Bottle": 3, "Water Source": 1 }, "products": { "Water Bottle": 3 } },
+    { "id": 90, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Water Bottle": 3 } },
+    { "id": 91, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Water Bottle": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Water Bottle": 3 } },
+  
+    { "id": 92, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Water Bottle": 3, "Nether Wart": 1, "Blaze Powder": 0.05 }, "products": { "Awkward Potion": 3 } },
+    { "id": 93, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Awkward Potion": 3, "Gunpowder": 1, "Blaze Powder": 0.05 }, "products": { "Splash Awkward Potion": 3 } },
+    { "id": 94, "category": "Brewing", "requirements": { "Brewing Stand": 1 }, "ingredients": { "Splash Awkward Potion": 3, "Dragon's Breath": 1, "Blaze Powder": 0.05 }, "products": { "Lingering Awkward Potion": 3 } }
+]

--- a/src/crafterlib/data/games/minecraft/root.json
+++ b/src/crafterlib/data/games/minecraft/root.json
@@ -6,6 +6,7 @@
         "machines.json"
     ],
     "recipe_files": [
-        "recipes.json"
+        "recipes.json",
+        "recipes_potions.json"
     ]
 }

--- a/test_data/games/test_game3/items.json
+++ b/test_data/games/test_game3/items.json
@@ -1,0 +1,37 @@
+[
+    {
+        "id": 1,
+        "name": "Sand",
+        "sources": []
+    },
+    {
+        "id": 2,
+        "name": "Water",
+        "sources": []
+    },
+    {
+        "id": 3,
+        "name": "Shovel",
+        "sources": []
+    },
+    {
+        "id": 4,
+        "name": "Bucket",
+        "sources": []
+    },
+    {
+        "id": 5,
+        "name": "Sand Pile",
+        "sources": []
+    },
+    {
+        "id": 6,
+        "name": "Sand Castle",
+        "sources": []
+    },
+    {
+        "id": 7,
+        "name": "Large Sand Castle",
+        "sources": []
+    }
+]

--- a/test_data/games/test_game3/recipes.json
+++ b/test_data/games/test_game3/recipes.json
@@ -1,0 +1,42 @@
+[
+    {
+        "id": 1,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Sand": 2,
+            "Water": 3,
+            "Shovel": 1
+        },
+        "products": {
+            "Sand Pile": 1
+        }
+    },
+    {
+        "id": 2,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Sand Pile": 1,
+            "Sand": 1,
+            "Water": 1,
+            "Bucket": 1
+        },
+        "products": {
+            "Sand Castle": 1
+        }
+    },
+    {
+        "id": 3,
+        "category": "Crafting",
+        "requirements": {},
+        "ingredients": {
+            "Sand Castle": 1,
+            "Water": 2,
+            "Bucket": 1
+        },
+        "products": {
+            "Large Sand Castle": 1
+        }
+    }
+]

--- a/test_data/games/test_game3/root.json
+++ b/test_data/games/test_game3/root.json
@@ -1,0 +1,9 @@
+{
+    "game": "Sand Game",
+    "item_files": [
+        "items.json"
+    ],
+    "recipe_files": [
+        "recipes.json"
+    ]
+}

--- a/tests/craftutils/test_recipe_chain.py
+++ b/tests/craftutils/test_recipe_chain.py
@@ -1,0 +1,142 @@
+"""This file is part of crafterlib.
+
+SPDX-License-Identifier: MIT
+"""
+from crafterlib import load_data_for_game
+from crafterlib.craftutils import get_recipe_chain
+
+def test_direct_ingredient():
+    game_data = load_data_for_game("test_game2", "test_data")
+
+    output = get_recipe_chain(game_data, "Silica Sand", "Silicon", False)
+    assert output == [{
+            "ingredients": { "Silica Sand": 36 },
+            "products": { "Silicon": 1 }
+        }]
+    
+def test_direct_ingredient_combine_ingredients():
+    game_data = load_data_for_game("test_game2", "test_data")
+
+    output = get_recipe_chain(game_data, "Silica Sand", "Silicon", True)
+    assert output == [{
+            "ingredients": { "Silica Sand": 36 },
+            "products": { "Silicon": 1 }
+        }]
+    
+def test_indirect_ingredient():
+    game_data = load_data_for_game("test_game2", "test_data")
+
+    output = get_recipe_chain(game_data, "Silica Sand", "Computer", False)
+    assert output == [
+    {
+        "ingredients": { "Silica Sand": 36 },
+        "products": { "Silicon": 1 }
+    },
+    {
+        "ingredients": { "Silicon": 2 },
+        "products": { "Polysilicon": 1 }
+    },
+    {
+        "ingredients": { "Polysilicon": 3 },
+        "products": { "Silicon Wafers": 2 }
+    },
+    {
+        "ingredients": { "Silicon Wafers": 3 },
+        "products": { "Integrated Circuit": 1 }
+    },
+    {
+        "ingredients": { "Integrated Circuit": 4 },
+        "products": { "Electronics Module": 1 }
+    },
+    {
+        "ingredients": { "Electronics Module": 7 },
+        "products": {"Computer": 1 }
+    }
+]
+    
+def test_ingredient_not_found():
+    game_data = load_data_for_game("test_game2", "test_data")
+
+    # Test with string that doesn't match
+    output = get_recipe_chain(game_data, "-", "Silicon", False)
+    assert output == None
+
+    # Test with empty string
+    output = get_recipe_chain(game_data, "", "Silicon", False)
+    assert output == None
+
+def test_product_not_found():
+    game_data = load_data_for_game("test_game2", "test_data")
+
+    # Test with string that doesn't match
+    output = get_recipe_chain(game_data, "Silicon", "-", False)
+    assert output == None
+
+    # Test with empty string
+    output = get_recipe_chain(game_data, "Silicon", "", False)
+    assert output == None
+
+def test_connection_not_found():
+    game_data = load_data_for_game("test_game2", "test_data")
+
+    # Test with inverted parameters
+    output = get_recipe_chain(game_data, "Silicon", "Silica Sand", False)
+    assert output == None
+
+    # Test with the same item for both parameters
+    output = get_recipe_chain(game_data, "Silicon", "Silicon", False)
+    assert output == None
+
+
+def test_recyclables():
+    game_data = load_data_for_game("minecraft")
+
+    # Gold Ingot and Gold Nugget can be crafted into each other
+    # and are therefore each other's ingredients.
+    output = get_recipe_chain(game_data, "Gold Ingot", "Gold Nugget", False)
+    assert output == [{
+            "ingredients": { "Gold Ingot": 1 },
+            "products": { "Gold Nugget": 9 }
+        }]
+    
+    # Test the other way around
+    output = get_recipe_chain(game_data, "Gold Nugget", "Gold Ingot", False)
+    assert output == [{
+            "ingredients": { "Gold Nugget": 9 },
+            "products": { "Gold Ingot": 1 }
+        }]
+    
+def test_equal_recyclables():
+    game_data = load_data_for_game("minecraft")
+
+    # Test with the same ingredient and product.
+    # There is a recipe chain through Gold Nugget
+    # but the function should return None
+    # since the parameters are the same.
+    output = get_recipe_chain(game_data, "Gold Ingot", "Gold Ingot", False)
+    assert output == None
+
+def test_combine_ingredients():
+    game_data = load_data_for_game("minecraft")
+
+    # Test with a potion that needs Blaze Powder
+    # in multiple recipes.
+    output = get_recipe_chain(game_data, "Water Bottle", "Splash Potion of Invisibility", False)
+    assert output == [
+        {
+            "ingredients": { "Water Bottle": 3, "Nether Wart": 1, "Blaze Powder": 0.2 },
+            "products": { "Awkward Potion": 3 } 
+        },
+        {
+            "ingredients": { "Awkward Potion": 3, "Golden Carrot": 1 },
+            "products": { "Potion of Night Vision": 3 }
+        },
+        {
+            "ingredients": { "Potion of Night Vision": 3, "Fermented Spider Eye": 1 },
+            "products": { "Potion of Invisibility": 3 }
+        },
+        {
+            "ingredients": { "Potion of Invisibility": 3, "Gunpowder": 1 },
+            "products": { "Splash Potion of Invisibility": 3 }
+        }
+    ]

--- a/tests/craftutils/test_recipe_chain.py
+++ b/tests/craftutils/test_recipe_chain.py
@@ -121,7 +121,7 @@ def test_combine_ingredients():
 
     # Test with a potion that needs Blaze Powder
     # in multiple recipes.
-    output = get_recipe_chain(game_data, "Water Bottle", "Splash Potion of Invisibility", False)
+    output = get_recipe_chain(game_data, "Water Bottle", "Splash Potion of Invisibility", True)
     assert output == [
         {
             "ingredients": { "Water Bottle": 3, "Nether Wart": 1, "Blaze Powder": 0.2 },
@@ -138,5 +138,25 @@ def test_combine_ingredients():
         {
             "ingredients": { "Potion of Invisibility": 3, "Gunpowder": 1 },
             "products": { "Splash Potion of Invisibility": 3 }
+        }
+    ]
+
+def test_combine_ingredients_complex():
+    game_data = load_data_for_game("test_game3", "test_data")
+
+    # Test with a game that needs the same ingredients in multiple steps
+    output = get_recipe_chain(game_data, "Shovel", "Large Sand Castle", True)
+    assert output == [
+        {
+            "ingredients": { "Sand": 3, "Water": 6, "Shovel": 1 },
+            "products": { "Sand Pile": 1 }
+        },
+        {
+            "ingredients": { "Sand Pile": 1, "Bucket": 2 },
+            "products": { "Sand Castle": 1 }
+        },
+        {
+            "ingredients": { "Sand Castle": 1 },
+            "products": { "Large Sand Castle": 1 }
         }
     ]


### PR DESCRIPTION
Will resolve this issue: https://github.com/JFarNTIG/crafterlib/issues/11

- [x]  My code follows the style guide (docs/style.md)
- [x]  Unit tests were added
- [ ]  Unit tests will be added later after some review
- [ ]  Unit tests weren't necessary

I added new recipes for a lot of Minecraft potions, their ingredients and new test data.

I also created a new craftutils function named `get_recipe_chain`. This function returns a path between two items in the form of a list of recipes. These recipes only includes ingredients and products. I chose to remove the rest of the data that's attached to each recipe because it wasn't needed and not including it made testing easier.

I added a number of new unit tests to test this function with different data, parameters and edge cases. All these tests are currently passing.

Lastly I added a new example that shows how this function works and how it can be used to display Minecraft potion recipes.