### PR TITLE
Start adding mob drops as a source of ingredients

### DIFF
--- a/src/crafterlib/data/games/minecraft/mobs.json
+++ b/src/crafterlib/data/games/minecraft/mobs.json
@@ -1,0 +1,119 @@
+[
+    {
+        "id": 1,
+        "mob": "Zombie",
+        "common_drops": ["0-2 Rotten Flesh"],
+        "rare_drops": ["1 Iron Ingot 0,83%", "1 Carrot 0,83%", "1 Potato 0,83%", "Baked Potato if killed while on fire 0,83%", "1 Zombie head if killed by a charged creeper"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Armor and tools 8,5% if killed by a player or a wolf"]
+    },
+
+    {
+        "id": 2,
+        "mob": "Husk",
+        "common_drops": ["0-2 Rotten Flesh"],
+        "rare_drops": ["1 Iron Ingot 0,83%", "1 Carrot 0,83%", "1 Potato 0,83%", "Baked Potato if killed while on fire 0,83%"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Armor and tools 8,5% if killed by a player or a wolf"]
+    },
+
+    {
+        "id": 3,
+        "mob": "Zombie villager",
+        "common_drops": ["0-2 Rotten Flesh"],
+        "rare_drops": ["1 Iron Ingot 0,83%", "1 Carrot 0,83%", "1 Potato 0,83%", "Baked Potato if killed while on fire 0,83%"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Armor and tools 8,5% if killed by a player or a wolf"]
+    },
+
+    {
+        "id": 4,
+        "mob": "Drowned",
+        "common_drops": ["0-2 Rotten Flesh"],
+        "rare_drops": ["1 Copper Ingot 11%"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Trident 8,5%", "Fishing Rod 8,5%", "Nautilus Shell 100%", "Armor 8,5% if killed by a player"]
+    },
+
+    {
+        "id": 5,
+        "mob": "Skeleton",
+        "common_drops": ["0-2 Arrow", "0-2 Bone"],
+        "rare_drops": ["1 Skeleton Skull if killed by a charged creeper"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Bow 8,5%", "Armor 8,5% if killed by a player or a wolf"]
+    },
+
+    {
+        "id": 6,
+        "mob": "Stray",
+        "common_drops": ["0-2 Arrow", "0-2 Bone", "0-1 Arrow Of Slowness"],
+        "rare_drops": ["None"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Bow 8,5%", "Armor 8,5% if killed by a player or a wolf"]
+    },
+
+    {
+        "id": 7,
+        "mob": "Bogged",
+        "common_drops": ["0-2 Arrow", "0-2 Bone", "0-1 Arrow Of Posion"],
+        "rare_drops": ["None"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Bow 8,5%", "Armor 8,5% if killed by a player or a wolf"]
+    },
+
+    {
+        "id": 8,
+        "mob": "Creeper",
+        "common_drops": ["0-2 Gunpowder"],
+        "rare_drops": ["1 Random Music Disc if killed my a skeletons arrow", "1 Creeper Head if killed by a charged creeper"],
+        "farm_drops": ["None"],
+        "equipped_items": ["None"]
+    },
+
+    {
+        "id": 9,
+        "mob": "Cow",
+        "common_drops": ["1-3 Raw Beef", "0-2 Leather"],
+        "rare_drops": ["1-3 Steak if killed while on fire"],
+        "farm_drops": ["Milk Bucket if a Bucket is used on it"],
+        "equipped_items": ["None"]
+    },
+
+    {
+        "id": 10,
+        "mob": "Sheep",
+        "common_drops": ["1-2 Raw Mutton", "1 Wool if not sheared"],
+        "rare_drops": ["1-2 Cooked Mutton if killed while on fire"],
+        "farm_drops": ["1-3 Wool if sheared"],
+        "equipped_items": ["None"]
+    },
+
+    {
+        "id": 11,
+        "mob": "Pig",
+        "common_drops": ["1-3 Raw Porkchop"],
+        "rare_drops": ["1-3 Cooked Porkchop if killed while on fire"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Saddle if equipped"]
+    },
+
+    {
+        "id": 12,
+        "mob": "Chicken",
+        "common_drops": ["0-2 Feather", "1 Raw Chicken"],
+        "rare_drops": ["1 Cooked Chicken if killed while on fire"],
+        "farm_drops": ["1 Egg every 5-10 minutes"],
+        "equipped_items": ["None"]
+    },
+
+    {
+        "id": 13,
+        "mob": "Iron Golem",
+        "common_drops": ["3-5 Iron ingot", "0-2 Poppy"],
+        "rare_drops": ["None"],
+        "farm_drops": ["None"],
+        "equipped_items": ["None"]
+    }
+
+]

--- a/src/crafterlib/data/games/minecraft/mobs.json
+++ b/src/crafterlib/data/games/minecraft/mobs.json
@@ -95,7 +95,7 @@
         "common_drops": ["1-3 Raw Porkchop"],
         "rare_drops": ["1-3 Cooked Porkchop if killed while on fire"],
         "farm_drops": ["None"],
-        "equipped_items": ["Saddle if equipped"]
+        "equipped_items": ["Saddle"]
     },
 
     {

--- a/src/crafterlib/mob.py
+++ b/src/crafterlib/mob.py
@@ -9,14 +9,26 @@ class Mob:
                  rare_drops: Set[str],
                  farm_drops: Set[str],
                  equipped_items: Set[str]):
+        # identifier for the mob class
         self.id=id
+
+        # name of the mob
         self.mob=mob
+
+        # items the mob commonly drops
         self.common_drops=common_drops
+
+        # items the mob rarely drops
         self.rare_drops=rare_drops
+
+        # items dropped when the mob is farmed
         self.farm_drops=farm_drops
+
+        # items the mob has equipped
         self.equipped_items=equipped_items
     
     def to_dict(self) -> Dict[str, Any]:
+        # convert the mob data into a dictionary for JSON serialization.
         return {
             "id": self.id,
             "mob": self.mob,
@@ -28,9 +40,10 @@ class Mob:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Mob":
+        # create a Mob instance from a dictionary
         return cls(
-            id=data.get("id", -1),
-            mob=data.get("mob", ""),
+            id=data.get("id", -1), # fallback ID if missing
+            mob=data.get("mob", ""), # empty string if name missing
             common_drops=set(data.get("common_drops", [])),
             rare_drops=set(data.get("rare_drops", [])),
             farm_drops=set(data.get("farm_drops", [])),
@@ -38,6 +51,8 @@ class Mob:
         )
 
     def __hash__(self):
+        # enables using Mob objects in sets or as dictionary keys.
+        # hash is based solely on the mob's ID.
         return hash(self.id)
     
     def __repr__(self) -> str:

--- a/src/crafterlib/mob.py
+++ b/src/crafterlib/mob.py
@@ -1,0 +1,51 @@
+from typing import Dict, Set, Any
+
+
+class Mob:
+    def __init__(self,
+                 id: int,
+                 mob: str,
+                 common_drops: Set[str],
+                 rare_drops: Set[str],
+                 farm_drops: Set[str],
+                 equipped_items: Set[str]):
+        self.id=id
+        self.mob=mob
+        self.common_drops=common_drops
+        self.rare_drops=rare_drops
+        self.farm_drops=farm_drops
+        self.equipped_items=equipped_items
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "mob": self.mob,
+            "common_drops": list(self.common_drops),
+            "rare_drops": list(self.rare_drops),
+            "farm_drops": list(self.farm_drops),
+            "equipped_items": list(self.equipped_items)
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Mob":
+        return cls(
+            id=data.get("id", -1),
+            mob=data.get("mob", ""),
+            common_drops=set(data.get("common_drops", [])),
+            rare_drops=set(data.get("rare_drops", [])),
+            farm_drops=set(data.get("farm_drops", [])),
+            equipped_items=set(data.get("equipped_items", []))
+        )
+
+    def __hash__(self):
+        return hash(self.id)
+    
+    def __repr__(self) -> str:
+        return (
+            f"Mob(id={self.id!r}, "
+            f"mob={self.mob!r}, "
+            f"common_drops={self.common_drops!r}, "
+            f"rare_drops={self.rare_drops!r})"
+            f"farm_drops={self.farm_drops!r})"
+            f"equipped_items={self.equipped_items!r})"
+        )

--- a/tests/test_mob.py
+++ b/tests/test_mob.py
@@ -1,6 +1,7 @@
 from crafterlib.mob import Mob
 
 def test_mob_from_dict():
+    # create a dictionary representing a mob, simulating data loaded from JSON
     mob_dict = {
         "id": 1,
         "mob": "Zombie",
@@ -10,20 +11,25 @@ def test_mob_from_dict():
         "equipped_items": ["Armor and tools 8.5% if killed by a player or a wolf"]
     }
 
+    # build a Mob instance using the from_dict factory method
     mob = Mob.from_dict(mob_dict)
 
+    # attribute checks
     assert mob.id == 1
     assert mob.mob == "Zombie"
 
+    # ensure that list inputs were correctly converted to sets
     assert isinstance(mob.common_drops, set)
     assert "0-2 Rotten Flesh" in mob.common_drops
 
+    # check that all sets contain expected values
     assert mob.rare_drops == {"1 Iron Ingot 0.83%", "1 Carrot 0.83%"}
     assert mob.farm_drops == {"None"}
     assert mob.equipped_items == {"Armor and tools 8.5% if killed by a player or a wolf"}
 
 
 def test_mob_to_dict():
+    # create a Mob instance
     mob = Mob(
         id=13,
         mob="Iron Golem",
@@ -33,13 +39,17 @@ def test_mob_to_dict():
         equipped_items={"None"}
     )
 
+    # convert it into a plain dictionary
     mob_dict = mob.to_dict()
 
+    # ensure all required keys exist in the dict
     expected_keys = {"id", "mob", "common_drops", "rare_drops", "farm_drops", "equipped_items"}
     assert set(mob_dict.keys()) == expected_keys
 
+    # check that sets were correctly converted to lists for serialization
     assert isinstance(mob_dict["common_drops"], list)
     assert "3-5 Iron Ingot" in mob_dict["common_drops"]
 
+    # value check
     assert mob_dict["mob"] == "Iron Golem"
     assert "None" in mob_dict["rare_drops"]

--- a/tests/test_mob.py
+++ b/tests/test_mob.py
@@ -1,0 +1,45 @@
+from crafterlib.mob import Mob
+
+def test_mob_from_dict():
+    mob_dict = {
+        "id": 1,
+        "mob": "Zombie",
+        "common_drops": ["0-2 Rotten Flesh"],
+        "rare_drops": ["1 Iron Ingot 0.83%", "1 Carrot 0.83%"],
+        "farm_drops": ["None"],
+        "equipped_items": ["Armor and tools 8.5% if killed by a player or a wolf"]
+    }
+
+    mob = Mob.from_dict(mob_dict)
+
+    assert mob.id == 1
+    assert mob.mob == "Zombie"
+
+    assert isinstance(mob.common_drops, set)
+    assert "0-2 Rotten Flesh" in mob.common_drops
+
+    assert mob.rare_drops == {"1 Iron Ingot 0.83%", "1 Carrot 0.83%"}
+    assert mob.farm_drops == {"None"}
+    assert mob.equipped_items == {"Armor and tools 8.5% if killed by a player or a wolf"}
+
+
+def test_mob_to_dict():
+    mob = Mob(
+        id=13,
+        mob="Iron Golem",
+        common_drops={"3-5 Iron Ingot", "0-2 Poppy"},
+        rare_drops={"None"},
+        farm_drops={"None"},
+        equipped_items={"None"}
+    )
+
+    mob_dict = mob.to_dict()
+
+    expected_keys = {"id", "mob", "common_drops", "rare_drops", "farm_drops", "equipped_items"}
+    assert set(mob_dict.keys()) == expected_keys
+
+    assert isinstance(mob_dict["common_drops"], list)
+    assert "3-5 Iron Ingot" in mob_dict["common_drops"]
+
+    assert mob_dict["mob"] == "Iron Golem"
+    assert "None" in mob_dict["rare_drops"]


### PR DESCRIPTION
Fixes #14 

This PR adds a new data model for mob drops, which allows mob drops to be used as a source of ingrediants.

- [x] My code follows the style guide (docs/style.md)
- [x] Unit tests were added
- [ ] Unit tests will be added later after some review
- [ ] Unit tests weren't necessary

added:

`mobs.json` for storing mob data like:
- name
- ID
- common, rare and farm drops
- equipped items

`mob.py` for defining  the `Mob` class which supports serialization and deserialization (`to_dict()` and `from_dict()`)

`test_mob.py` which tests `Mob.from_dict()` and `Mob.to_dict()`


The `Mob` class uses object-oriented principles to model mobs as reusable entities.  Sets and dictionaries are used to manage drop lists efficiently and prevent duplicates.

The current implementation is static — mob drops are hardcoded in JSON. In the future, probabilities and conditions could be structured programmatically instead of stored as text.